### PR TITLE
Reverse Search through History

### DIFF
--- a/src/command.cpp
+++ b/src/command.cpp
@@ -521,8 +521,8 @@ void Command::popDir() {
 }
 
 void Command::send_to_foreground(ssize_t job_num,
-								 bool & fg,
-								 termios & _oldtermios)
+                                 bool & fg,
+                                 termios & _oldtermios)
 {
     pid_t current = m_shell_pgid;
     if (m_jobs.size()) {

--- a/src/shell-readline.cpp
+++ b/src/shell-readline.cpp
@@ -735,6 +735,10 @@ bool read_line::handle_up_arrow(std::string & _line)
     if (!hist->size()) return false;
 
     /* clear input so far */
+    std::string ending = "";
+    for (; m_buff.size(); m_buff.pop()) ending += m_buff.top();
+    if (!write_with_error(1, ending.c_str(), ending.size())) return false;
+    _line += ending;
     char ch[_line.size() + 1]; char sp[_line.size() + 1];
     memset(ch, '\b',_line.size()); memset(sp, ' ', _line.size());
 
@@ -751,7 +755,7 @@ bool read_line::handle_up_arrow(std::string & _line)
 
     /* print the line */
     if (_line.size()) _line.pop_back();
-    if (!write_with_error(1, _line.c_str(), _line.size())) return false;
+    if (!write_with_error(1, _line.c_str(), _line.size()) || !rev_search) return false;
     if (!search_mode) search_str = "";
     size_t len_diff = 0;
     for (; m_buff.size();) m_buff.pop();
@@ -804,7 +808,12 @@ bool read_line::handle_down_arrow(std::string & _line)
 
     if (*index == hist->size()) return false;
 
+
     /* clear input so far */
+    std::string ending = "";
+    for (; m_buff.size(); m_buff.pop()) ending += m_buff.top();
+    if (!write_with_error(1, ending.c_str(), ending.size())) return false;
+    _line += ending;
     char ch[_line.size() + 1]; char sp[_line.size() + 1];
     memset(ch, '\b',_line.size()); memset(sp, ' ', _line.size());
 
@@ -820,7 +829,7 @@ bool read_line::handle_down_arrow(std::string & _line)
     }
 
     /* print the line */
-    if (!write_with_error(1, _line.c_str(), _line.size())) return false;
+    if (!write_with_error(1, _line.c_str(), _line.size()) || !rev_search) return false;
     if (!search_mode) search_str = "";
     size_t len_diff = 0;
     /* clear the buffer */

--- a/src/shell-readline.cpp
+++ b/src/shell-readline.cpp
@@ -713,6 +713,10 @@ bool read_line::handle_up_arrow(std::string & _line)
     bool search_mode = false;
     search_mode = rev_search && !strcmp(rev_search, "UP_ARROW");
 
+    /**
+     * TODO(allenh1): it's not great that this copies the history
+     * every time -- can we not do that in non-reverse-search mode?
+     */
     std::vector<std::string> hist;
     if (search_mode) {
         auto it = std::copy_if(
@@ -721,7 +725,7 @@ bool read_line::handle_up_arrow(std::string & _line)
                 return (s.size() >= _line.size()) &&
                 s.substr(0, _line.size()) == _line;
             });
-        history_index = 0; /* reset */
+        history_index = hist.size(); /* reset */
     } else hist = m_history;
     if (!hist.size()) return false;
 

--- a/src/shell-readline.cpp
+++ b/src/shell-readline.cpp
@@ -720,7 +720,8 @@ bool read_line::handle_up_arrow(std::string & _line)
     std::vector<std::string> hist;
     if (search_mode) {
         auto it = std::copy_if(
-            m_history.begin(), m_history.end(), std::back_inserter(hist),
+            m_history.begin(), m_history.end(),
+            std::back_inserter(hist),
             [_line](const auto & s) {
                 return (s.size() >= _line.size()) &&
                 s.substr(0, _line.size()) == _line;

--- a/src/shell-readline.cpp
+++ b/src/shell-readline.cpp
@@ -708,12 +708,9 @@ bool read_line::handle_up_arrow(std::string & _line)
     /* check for the reverse search mode variable */
     const char * rev_search = getenv("REV_SEARCH_MODE");
     bool search_mode = false;
-    search_mode = rev_search && !strcmp(rev_search, "UP_ARROW");
+    search_mode =
+        rev_search && !strcmp(rev_search, "UP_ARROW") && _line.size();
 
-    /**
-     * TODO(allenh1): it's not great that this copies the history
-     * every time -- can we not do that in non-reverse-search mode?
-     */
     std::vector<std::string> * hist;
     ssize_t * index = &history_index;
     if (search_mode) {
@@ -729,8 +726,8 @@ bool read_line::handle_up_arrow(std::string & _line)
                     return (s.size() >= _line.size()) &&
                     s.substr(0, _line.size()) == _line;
                 });
+            search_index = hist->size();
         } else hist = &m_rev_search;
-        search_index = hist->size();
         index = &search_index;
     } else hist = &m_history;
 
@@ -745,28 +742,28 @@ bool read_line::handle_up_arrow(std::string & _line)
     else if (!write_with_error(1, sp, _line.size())) return false;
     else if (!write_with_error(1, ch, _line.size())) return false;
 
+    /* stay in bounds */
     if ((size_t) *index == hist->size()) --(*index);
 
     /* only decrement if we are going beyond the first command (duh) */
+    if (*index) *index = *index - 1;
     _line = hist->at(*index);
-    if (*index) (*index)--;
 
     /* print the line */
     if (_line.size()) _line.pop_back();
     if (!write_with_error(1, _line.c_str(), _line.size())) return false;
-    if (search_mode) {
-        size_t len_diff = 0;
-        for (; m_buff.size();) m_buff.pop();
+    if (!search_mode) search_str = "";
+    size_t len_diff = 0;
+    for (; m_buff.size();) m_buff.pop();
 
-        /* fill the buffer */
-        for (; _line != search_str; ++len_diff) {
-            m_buff.push(_line.back());
-            _line.pop_back();
-        }
-        /* iterate back to search prefix */
-        char ch2[len_diff]; memset(ch2, '\b', len_diff);
-        if (!write_with_error(1, ch2, len_diff)) return false;
+    /* fill the buffer */
+    for (; _line != search_str; ++len_diff) {
+        m_buff.push(_line.back());
+        _line.pop_back();
     }
+    /* iterate back to search prefix */
+    char ch2[len_diff]; memset(ch2, '\b', len_diff);
+    if (!write_with_error(1, ch2, len_diff)) return false;
     return false;
 }
 
@@ -779,7 +776,33 @@ bool read_line::handle_up_arrow(std::string & _line)
  */
 bool read_line::handle_down_arrow(std::string & _line)
 {
-    if (!m_history.size()) return false;
+    /* check for the reverse search mode variable */
+    const char * rev_search = getenv("REV_SEARCH_MODE");
+    bool search_mode = false;
+    search_mode =
+        rev_search && !strcmp(rev_search, "UP_ARROW") && _line.size();
+
+    std::vector<std::string> * hist = &m_history;
+    ssize_t * index = &history_index;
+    if (search_mode) {
+        if (_line != search_str) {
+            m_rev_search.clear();
+            m_rev_search.shrink_to_fit();
+            hist = &m_rev_search;
+            search_str = _line;
+            auto it = std::copy_if(
+                m_history.begin(), m_history.end(),
+                std::back_inserter(*hist),
+                [_line](const auto & s) {
+                    return (s.size() >= _line.size()) &&
+                    s.substr(0, _line.size()) == _line;
+                });
+            search_index = hist->size();
+        } else hist = &m_rev_search;
+        index = &search_index;
+    }
+
+    if (*index == hist->size()) return false;
 
     /* clear input so far */
     char ch[_line.size() + 1]; char sp[_line.size() + 1];
@@ -789,16 +812,29 @@ bool read_line::handle_down_arrow(std::string & _line)
     else if (!write_with_error(1, sp, _line.size())) return false;
     else if (!write_with_error(1, ch, _line.size())) return false;
 
-    history_index = ((size_t) history_index == m_history.size()) ? m_history.size()
-        : history_index + 1;
-    if ((size_t) history_index == m_history.size()) _line = m_current_line_copy;
-    else _line = m_history[history_index];
-    if (_line.size() && (size_t) history_index != m_history.size()) _line.pop_back();
-    // Print the line
-    if (write(1, _line.c_str(), _line.size()) != (int) _line.size()) {
-        perror("write");
-        return false;
+    /* don't increment past the last command */
+    if (((*index)) != hist->size() - 1) {
+        (*index)++;
+        _line = hist->at(*index);
+        _line.pop_back();
     }
+
+    /* print the line */
+    if (!write_with_error(1, _line.c_str(), _line.size())) return false;
+    if (!search_mode) search_str = "";
+    size_t len_diff = 0;
+    /* clear the buffer */
+    for (; m_buff.size();) m_buff.pop();
+
+    /* fill the buffer */
+    for (; _line != search_str; ++len_diff) {
+        m_buff.push(_line.back());
+        _line.pop_back();
+    }
+    /* iterate back to search prefix */
+    char ch2[len_diff]; memset(ch2, '\b', len_diff);
+    if (!write_with_error(1, ch2, len_diff)) return false;
+    return false;
 }
 
 /**

--- a/src/shell-readline.hpp
+++ b/src/shell-readline.hpp
@@ -63,19 +63,19 @@ public:
 	bool handle_bang(std::string & _line);
 	bool handle_delete(std::string & _line);
 	bool handle_tab(std::string & _line);
-   
+
 	bool handle_ctrl_a(std::string & _line);
 	bool handle_ctrl_d(std::string & _line);
 	bool handle_ctrl_e(std::string & _line);
 	bool handle_ctrl_k(std::string & _line);
-	bool handle_ctrl_del(std::string & _line);	
+	bool handle_ctrl_del(std::string & _line);
 	bool handle_ctrl_arrow(std::string & _line);
 
 	bool handle_up_arrow(std::string & _line);
 	bool handle_down_arrow(std::string & _line);
 	bool handle_left_arrow(std::string & _line);
 	bool handle_right_arrow(std::string & _line);
-  
+
 	void operator() () {
 		// Raw mode
 		char input;
@@ -98,7 +98,7 @@ public:
 					 * in the middle of a line.
 					 */
 					_line += input;
-	  
+
 					/* Write current character */
 					if (!write_with_error(1, input)) continue;
 
@@ -135,14 +135,14 @@ public:
 			}
 			else if ((input == 8 || input == 127) && !handle_backspace(_line)) continue;
 			else if (input == 9 && !handle_tab(_line)) continue;
-			else if (input == 27) {	
+			else if (input == 27) {
 				char ch1, ch2, ch3;
 				// Read the next two chars
 				if (!read_with_error(0, ch1)) continue;
 				else if (!read_with_error(0, ch2)) continue;
 				else if (ch1 == 91 && ch2 == 51 && !read_with_error(0, ch3)) continue;
 				/* handle ctrl + arrow key */
-				if ((ch1 == 91 && ch2 == 49) && !handle_ctrl_arrow(_line)) continue;			
+				if ((ch1 == 91 && ch2 == 49) && !handle_ctrl_arrow(_line)) continue;
 				else if (ch1 == 91 && ch2 == 51 && ch3 == 126
 						 && !handle_delete(_line)) continue;
 				else if (ch1 == 91 && ch2 == 51 && ch3 == 59
@@ -153,7 +153,7 @@ public:
 				if (ch1 == 91 && ch2 == 68 && !handle_left_arrow(_line)) continue;
 			}
 		}
-		
+
 		if (_line.size()) {
             std::string _file = tilde_expand("~/.cache/yash_history");
             int history_fd = open(_file.c_str(), O_CREAT | O_APPEND | O_WRONLY, 0600);
@@ -173,7 +173,7 @@ public:
 		std::cerr<<"get returning: "<<ret<<std::endl;
 		return ret;
 	}
-  
+
 	char * get() {
 		if (m_get_mode == 2) {
 			char * ret = (char*) calloc(m_stashed.size() + 1, sizeof(char));
@@ -183,7 +183,7 @@ public:
 			std::cerr<<"get returning: "<<ret<<std::endl;
 			return ret;
 		}
-      
+
 		std::string returning;
 		returning = m_history[m_history.size() - 1];
 		/* returning.pop_back(); */
@@ -193,22 +193,20 @@ public:
 		return ret;
 	}
 
-   
 	void tty_raw_mode() {
 		pid_t pid = Command::currentCommand.m_shell_pgid;
 		/* become a strong independent black woman */
 		tcsetpgrp(0, pid);
 		/* save defaults for later */
-		tcgetattr(0,&oldtermios);		
+		tcgetattr(0,&oldtermios);
 		termios tty_attr = oldtermios;
 		/* set raw mode */
 		tty_attr.c_lflag &= (~(ICANON|ECHO));
 		tty_attr.c_cc[VTIME] = 0;
 		tty_attr.c_cc[VMIN] = 1;
-			
 		tcsetattr(0,TCSANOW,&tty_attr);
 	}
-	
+
 	void unset_tty_raw_mode() {
 		tcsetattr(0, TCSAFLUSH, &oldtermios);
 	}

--- a/src/shell-readline.hpp
+++ b/src/shell-readline.hpp
@@ -49,210 +49,210 @@ extern int yyparse();
 class read_line
 {
 public:
-	read_line();
+    read_line();
 
-	bool write_with_error(int _fd, char & c);
-	bool write_with_error(int _fd, const char * s);
-	bool write_with_error(int _fd, const char * s, const size_t & len);
+    bool write_with_error(int _fd, char & c);
+    bool write_with_error(int _fd, const char * s);
+    bool write_with_error(int _fd, const char * s, const size_t & len);
 
-	bool read_with_error(int _fd, char & c);
-	size_t get_term_width();
+    bool read_with_error(int _fd, char & c);
+    size_t get_term_width();
 
-	bool handle_enter(std::string & _line, char & input);
-	bool handle_backspace(std::string & _line);
-	bool handle_bang(std::string & _line);
-	bool handle_delete(std::string & _line);
-	bool handle_tab(std::string & _line);
+    bool handle_enter(std::string & _line, char & input);
+    bool handle_backspace(std::string & _line);
+    bool handle_bang(std::string & _line);
+    bool handle_delete(std::string & _line);
+    bool handle_tab(std::string & _line);
 
-	bool handle_ctrl_a(std::string & _line);
-	bool handle_ctrl_d(std::string & _line);
-	bool handle_ctrl_e(std::string & _line);
-	bool handle_ctrl_k(std::string & _line);
-	bool handle_ctrl_del(std::string & _line);
-	bool handle_ctrl_arrow(std::string & _line);
+    bool handle_ctrl_a(std::string & _line);
+    bool handle_ctrl_d(std::string & _line);
+    bool handle_ctrl_e(std::string & _line);
+    bool handle_ctrl_k(std::string & _line);
+    bool handle_ctrl_del(std::string & _line);
+    bool handle_ctrl_arrow(std::string & _line);
 
-	bool handle_up_arrow(std::string & _line);
-	bool handle_down_arrow(std::string & _line);
-	bool handle_left_arrow(std::string & _line);
-	bool handle_right_arrow(std::string & _line);
+    bool handle_up_arrow(std::string & _line);
+    bool handle_down_arrow(std::string & _line);
+    bool handle_left_arrow(std::string & _line);
+    bool handle_right_arrow(std::string & _line);
 
-	void operator() () {
-		// Raw mode
-		char input;
-		std::string _line = "";
+    void operator() () {
+        // Raw mode
+        char input;
+        std::string _line = "";
 
-		// Read in the next character
-		for (; true ;) {
-			/* If you can't read from 0, don't continue! */
-			if (!read_with_error(0, input)) break;
+        // Read in the next character
+        for (; true ;) {
+            /* If you can't read from 0, don't continue! */
+            if (!read_with_error(0, input)) break;
 
-			// Echo the character to the screen
-			if (input >= 32 && input != 127) {
-				// Character is printable
-				if (input == '!') {
-					if (!handle_bang(_line)) continue;
-					else break;
-				} else if (m_buff.size()) {
-					/**
-					 * If the buffer has contents, they are
-					 * in the middle of a line.
-					 */
-					_line += input;
+            // Echo the character to the screen
+            if (input >= 32 && input != 127) {
+                // Character is printable
+                if (input == '!') {
+                    if (!handle_bang(_line)) continue;
+                    else break;
+                } else if (m_buff.size()) {
+                    /**
+                     * If the buffer has contents, they are
+                     * in the middle of a line.
+                     */
+                    _line += input;
 
-					/* Write current character */
-					if (!write_with_error(1, input)) continue;
+                    /* Write current character */
+                    if (!write_with_error(1, input)) continue;
 
-					/* Copy buffer and print */
-					std::stack<char> temp = m_buff;
-					for (char d = 0; temp.size(); ) {
-						d = temp.top(); temp.pop();
-						if (!write_with_error(1, d)) continue;
-					}
+                    /* Copy buffer and print */
+                    std::stack<char> temp = m_buff;
+                    for (char d = 0; temp.size(); ) {
+                        d = temp.top(); temp.pop();
+                        if (!write_with_error(1, d)) continue;
+                    }
 
-					// Move cursor to current position.
-					for (size_t x = 0; x < m_buff.size(); ++x) {
-						if (!write_with_error(1, "\b", 1)) continue;
-					}
-				} else {
-					_line += input;
-					if ((size_t)history_index == m_history.size())
-						m_current_line_copy += input;
-					/* Write to screen */
-					if (!write_with_error(1, input)) continue;
-				}
-			} else if (input == 10) {
-				if (handle_enter(_line, input)) break;
-				else continue;
-			} else if (input == 1) {
-				if (handle_ctrl_a(_line)) break;
-				else continue;
-			}
-			else if (input == 5 && !handle_ctrl_e(_line)) continue;
-			else if (input == 4 && !handle_ctrl_d(_line)) continue;
-			else if (input == 11) {
-				if (!handle_ctrl_k(_line)) continue;
-				else break;
-			}
-			else if ((input == 8 || input == 127) && !handle_backspace(_line)) continue;
-			else if (input == 9 && !handle_tab(_line)) continue;
-			else if (input == 27) {
-				char ch1, ch2, ch3;
-				// Read the next two chars
-				if (!read_with_error(0, ch1)) continue;
-				else if (!read_with_error(0, ch2)) continue;
-				else if (ch1 == 91 && ch2 == 51 && !read_with_error(0, ch3)) continue;
-				/* handle ctrl + arrow key */
-				if ((ch1 == 91 && ch2 == 49) && !handle_ctrl_arrow(_line)) continue;
-				else if (ch1 == 91 && ch2 == 51 && ch3 == 126
-						 && !handle_delete(_line)) continue;
-				else if (ch1 == 91 && ch2 == 51 && ch3 == 59
-						 && !handle_ctrl_del(_line)) continue;
-				if (ch1 == 91 && ch2 == 65 && !handle_up_arrow(_line)) continue;
-				if (ch1 == 91 && ch2 == 66 && !handle_down_arrow(_line)) continue;
-				if (ch1 == 91 && ch2 == 67 && !handle_right_arrow(_line)) continue;
-				if (ch1 == 91 && ch2 == 68 && !handle_left_arrow(_line)) continue;
-			}
-		}
+                    // Move cursor to current position.
+                    for (size_t x = 0; x < m_buff.size(); ++x) {
+                        if (!write_with_error(1, "\b", 1)) continue;
+                    }
+                } else {
+                    _line += input;
+                    if ((size_t)history_index == m_history.size())
+                        m_current_line_copy += input;
+                    /* Write to screen */
+                    if (!write_with_error(1, input)) continue;
+                }
+            } else if (input == 10) {
+                if (handle_enter(_line, input)) break;
+                else continue;
+            } else if (input == 1) {
+                if (handle_ctrl_a(_line)) break;
+                else continue;
+            }
+            else if (input == 5 && !handle_ctrl_e(_line)) continue;
+            else if (input == 4 && !handle_ctrl_d(_line)) continue;
+            else if (input == 11) {
+                if (!handle_ctrl_k(_line)) continue;
+                else break;
+            }
+            else if ((input == 8 || input == 127) && !handle_backspace(_line)) continue;
+            else if (input == 9 && !handle_tab(_line)) continue;
+            else if (input == 27) {
+                char ch1, ch2, ch3;
+                // Read the next two chars
+                if (!read_with_error(0, ch1)) continue;
+                else if (!read_with_error(0, ch2)) continue;
+                else if (ch1 == 91 && ch2 == 51 && !read_with_error(0, ch3)) continue;
+                /* handle ctrl + arrow key */
+                if ((ch1 == 91 && ch2 == 49) && !handle_ctrl_arrow(_line)) continue;
+                else if (ch1 == 91 && ch2 == 51 && ch3 == 126
+                         && !handle_delete(_line)) continue;
+                else if (ch1 == 91 && ch2 == 51 && ch3 == 59
+                         && !handle_ctrl_del(_line)) continue;
+                if (ch1 == 91 && ch2 == 65 && !handle_up_arrow(_line)) continue;
+                if (ch1 == 91 && ch2 == 66 && !handle_down_arrow(_line)) continue;
+                if (ch1 == 91 && ch2 == 67 && !handle_right_arrow(_line)) continue;
+                if (ch1 == 91 && ch2 == 68 && !handle_left_arrow(_line)) continue;
+            }
+        }
 
-		if (_line.size()) {
+        if (_line.size()) {
             std::string _file = tilde_expand("~/.cache/yash_history");
             int history_fd = open(_file.c_str(), O_CREAT | O_APPEND | O_WRONLY, 0600);
-			if (!write_with_error(history_fd, _line.c_str(), _line.size())) return;
-			else if (!write_with_error(history_fd, "\n", 1)) return;
+            if (!write_with_error(history_fd, _line.c_str(), _line.size())) return;
+            else if (!write_with_error(history_fd, "\n", 1)) return;
             close(history_fd);
-		} _line += (char) 10 + '\0';
-		m_current_line_copy.clear();
-		m_history.push_back(_line);
-	}
+        } _line += (char) 10 + '\0';
+        m_current_line_copy.clear();
+        m_history.push_back(_line);
+    }
 
-	char * getStashed() {
-		char * ret = (char*) calloc(m_stashed.size() + 1, sizeof(char));
-		strncpy(ret, m_stashed.c_str(), m_stashed.size());
-		ret[m_stashed.size()] = '\0';
-		m_get_mode = 1;
-		std::cerr<<"get returning: "<<ret<<std::endl;
-		return ret;
-	}
+    char * getStashed() {
+        char * ret = (char*) calloc(m_stashed.size() + 1, sizeof(char));
+        strncpy(ret, m_stashed.c_str(), m_stashed.size());
+        ret[m_stashed.size()] = '\0';
+        m_get_mode = 1;
+        std::cerr<<"get returning: "<<ret<<std::endl;
+        return ret;
+    }
 
-	char * get() {
-		if (m_get_mode == 2) {
-			char * ret = (char*) calloc(m_stashed.size() + 1, sizeof(char));
-			strncpy(ret, m_stashed.c_str(), m_stashed.size());
-			ret[m_stashed.size()] = '\0';
-			m_get_mode = 1;
-			std::cerr<<"get returning: "<<ret<<std::endl;
-			return ret;
-		}
+    char * get() {
+        if (m_get_mode == 2) {
+            char * ret = (char*) calloc(m_stashed.size() + 1, sizeof(char));
+            strncpy(ret, m_stashed.c_str(), m_stashed.size());
+            ret[m_stashed.size()] = '\0';
+            m_get_mode = 1;
+            std::cerr<<"get returning: "<<ret<<std::endl;
+            return ret;
+        }
 
-		std::string returning;
-		returning = m_history[m_history.size() - 1];
-		/* returning.pop_back(); */
-		char * ret = (char*) calloc(returning.size() + 1, sizeof(char));
-		strncpy(ret, returning.c_str(), returning.size());
-		ret[returning.size()] = '\0';
-		return ret;
-	}
+        std::string returning;
+        returning = m_history[m_history.size() - 1];
+        /* returning.pop_back(); */
+        char * ret = (char*) calloc(returning.size() + 1, sizeof(char));
+        strncpy(ret, returning.c_str(), returning.size());
+        ret[returning.size()] = '\0';
+        return ret;
+    }
 
-	void tty_raw_mode() {
-		pid_t pid = Command::currentCommand.m_shell_pgid;
-		/* become a strong independent black woman */
-		tcsetpgrp(0, pid);
-		/* save defaults for later */
-		tcgetattr(0,&oldtermios);
-		termios tty_attr = oldtermios;
-		/* set raw mode */
-		tty_attr.c_lflag &= (~(ICANON|ECHO));
-		tty_attr.c_cc[VTIME] = 0;
-		tty_attr.c_cc[VMIN] = 1;
-		tcsetattr(0,TCSANOW,&tty_attr);
-	}
+    void tty_raw_mode() {
+        pid_t pid = Command::currentCommand.m_shell_pgid;
+        /* become a strong independent black woman */
+        tcsetpgrp(0, pid);
+        /* save defaults for later */
+        tcgetattr(0,&oldtermios);
+        termios tty_attr = oldtermios;
+        /* set raw mode */
+        tty_attr.c_lflag &= (~(ICANON|ECHO));
+        tty_attr.c_cc[VTIME] = 0;
+        tty_attr.c_cc[VMIN] = 1;
+        tcsetattr(0,TCSANOW,&tty_attr);
+    }
 
-	void unset_tty_raw_mode() {
-		tcsetattr(0, TCSAFLUSH, &oldtermios);
-	}
+    void unset_tty_raw_mode() {
+        tcsetattr(0, TCSAFLUSH, &oldtermios);
+    }
 
-	void setFile(const std::string & _filename) {
-		std::string expanded_home = tilde_expand(_filename.c_str());
+    void setFile(const std::string & _filename) {
+        std::string expanded_home = tilde_expand(_filename.c_str());
 
-		char * file = strndup(expanded_home.c_str(), expanded_home.size());
+        char * file = strndup(expanded_home.c_str(), expanded_home.size());
 
-		yyin = fopen(file, "r"); free(file);
+        yyin = fopen(file, "r"); free(file);
 
-		if (yyin != NULL) {
-			Command::currentCommand.printPrompt = false;
-			yyrestart(yyin); yyparse();
-			fclose(yyin);
+        if (yyin != NULL) {
+            Command::currentCommand.printPrompt = false;
+            yyrestart(yyin); yyparse();
+            fclose(yyin);
 
-			yyin = stdin;
-			yyrestart(yyin);
-			Command::currentCommand.printPrompt = true;
-		} Command::currentCommand.prompt();
-		yyparse();
-	}
+            yyin = stdin;
+            yyrestart(yyin);
+            Command::currentCommand.printPrompt = true;
+        } Command::currentCommand.prompt();
+        yyparse();
+    }
 
-	void save_history();
-	void load_history();
-	const std::vector<std::string> & get_history() { return m_history; }
-	termios oldtermios;
+    void save_history();
+    void load_history();
+    const std::vector<std::string> & get_history() { return m_history; }
+    termios oldtermios;
 private:
-	std::vector<std::string> string_split(std::string s, char delim) {
-		std::vector<std::string> elems; std::stringstream ss(s);
-		std::string item;
-		for (;std::getline(ss, item, delim); elems.push_back(std::move(item)));
-		return elems;
-	}
-	std::string m_current_path;
-	std::string m_current_line_copy;
-	std::string m_stashed;
-	std::stack<char> m_buff;
-	std::vector<std::string> m_path;
-	ssize_t history_index = 0;
-	int fdin = 0;
-	int m_history_fd = 0;
-	std::string m_filename;
-	std::ifstream * m_ifstream;
-	int m_get_mode;
-	std::vector<std::string> m_history;
-	bool m_show_line = false;
+    std::vector<std::string> string_split(std::string s, char delim) {
+        std::vector<std::string> elems; std::stringstream ss(s);
+        std::string item;
+        for (;std::getline(ss, item, delim); elems.push_back(std::move(item)));
+        return elems;
+    }
+    std::string m_current_path;
+    std::string m_current_line_copy;
+    std::string m_stashed;
+    std::stack<char> m_buff;
+    std::vector<std::string> m_path;
+    ssize_t history_index = 0;
+    int fdin = 0;
+    int m_history_fd = 0;
+    std::string m_filename;
+    std::ifstream * m_ifstream;
+    int m_get_mode;
+    std::vector<std::string> m_history;
+    bool m_show_line = false;
 };
 #endif

--- a/src/shell-readline.hpp
+++ b/src/shell-readline.hpp
@@ -253,6 +253,9 @@ private:
     std::ifstream * m_ifstream;
     int m_get_mode;
     std::vector<std::string> m_history;
+    std::vector<std::string> m_rev_search;
+    ssize_t search_index = 0;
+    std::string search_str;
     bool m_show_line = false;
 };
 #endif

--- a/src/shell-utils.cpp
+++ b/src/shell-utils.cpp
@@ -1,3 +1,16 @@
+// Copyright 2016 YaSh Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #include "shell-utils.hpp"
 
 /** 
@@ -295,4 +308,3 @@ void timeval_to_secs (timeval & tvp,
 		sfp -= 1000;
 	}
 } 
-


### PR DESCRIPTION
This is the first form of reverse search history to be implemented in YaSh. If the user sets `REV_SEARCH_MODE` to `UP_ARROW`, then this behavior is used. This style of reverse search
history should mimic that of CSh.

@etheller FYI