### PR TITLE
Fix crash

### DIFF
--- a/src/command.cpp
+++ b/src/command.cpp
@@ -362,7 +362,7 @@ void Command::prompt()
   if (pmt) {PROMPT = std::string(pmt);} else {PROMPT = std::string("default");}
 
   if (isatty(0) && PROMPT == std::string("default")) {
-    std::string _user = std::string(getenv("USER"));
+    std::string _user = get_username();
     char buffer[100]; std::string _host;
     if (!gethostname(buffer, 100)) {_host = std::string(buffer);} else {
       _host = std::string("localhost");

--- a/src/shell-utils.cpp
+++ b/src/shell-utils.cpp
@@ -147,6 +147,22 @@ std::string tilde_expand(std::string input)
   return input;
 }
 
+std::string get_username()
+{
+  passwd * _passwd = new passwd();
+  auto at_exit = make_scope_exit(
+    [_passwd]() {
+        delete _passwd;
+      });
+  const size_t len = 1024;
+  auto buff = std::shared_ptr<char>(new char[len], [](auto s) {delete[] s;});
+  int ret = getpwuid_r(getuid(), _passwd, buff.get(), len, &_passwd);
+  if (ret || nullptr == _passwd) {
+    return std::string("<unknown user>");
+  }
+  return std::string(_passwd->pw_name);
+}
+
 /**
  * String replace function.
  *

--- a/src/shell-utils.hpp
+++ b/src/shell-utils.hpp
@@ -36,6 +36,7 @@ void printEvenly(std::vector<std::string> & _vct);
 std::string tilde_expand(std::string input);
 std::string replace(std::string str, const char * sb, const char * rep);
 std::string env_expand(std::string s);
+std::string get_username();
 std::vector<std::string> vector_split(std::string s, char delim);
 bool changedir(std::string & s);
 bool is_directory(std::string s);


### PR DESCRIPTION
When Ubuntu is started in docker, there is no definition of `USER`, which induced a crash when YaSh tried to generate the promt. This obtains the username via the `struct passwd`.